### PR TITLE
Add JavaDoc documentation to data structure interfaces

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -9,8 +9,8 @@
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/kh-data-tbl" />
-            <option value="$PROJECT_DIR$/kh-data-tbl-example" />
+            <option value="$PROJECT_DIR$/kh-data-structure" />
+            <option value="$PROJECT_DIR$/kh-data-example" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Gradle
 ```gradle
-implementation 'io.github.keyhub-projects:kh-data-structure:2.0.1'
+implementation 'io.github.keyhub-projects:kh-data-structure:1.0.0'
 ```
 
 # Structure

--- a/kh-data-structure/build.gradle
+++ b/kh-data-structure/build.gradle
@@ -10,14 +10,14 @@ plugins {
 }
 
 group = 'keyhub'
-version = '2.0.1'
+version = '1.0.0'
 
 repositories {
     mavenCentral()
 }
 
 java {
-//    withJavadocJar()
+    withJavadocJar()
     withSourcesJar()
 }
 

--- a/kh-data-structure/src/main/java/keyhub/data/structure/cell/KhCell.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/cell/KhCell.java
@@ -26,35 +26,165 @@ package keyhub.data.structure.cell;
 
 import keyhub.data.structure.column.KhColumn;
 
+import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+/**
+ * Interface representing a cell in a data structure.
+ *
+ * @param <T> the type of the cell value
+ */
 public interface KhCell<T> {
 
+    /**
+     * Creates an empty cell with the specified column schema.
+     *
+     * @param columnSchema the column schema
+     * @param <T> the type of the cell value
+     * @return an empty cell
+     */
     static<T> KhCell<T> empty(KhColumn<T> columnSchema) {
         return KhCellImplement.empty(columnSchema);
     }
+
+    /**
+     * Creates a cell with the specified column schema and value.
+     *
+     * @param columnSchema the column schema
+     * @param value the cell value
+     * @param <T> the type of the cell value
+     * @return a cell with the specified value
+     */
     static <T> KhCell<T> of(KhColumn<T> columnSchema, T value) {
         return KhCellImplement.of(columnSchema, value);
     }
 
+    /**
+     * Gets the value of the cell.
+     *
+     * @return the cell value
+     */
     T getValue();
+
+    /**
+     * Gets the column schema of the cell.
+     *
+     * @return the column schema
+     */
     KhColumn<T> getColumnSchema();
+
+    /**
+     * Gets the type of the cell value.
+     *
+     * @return the cell value type
+     */
     Class<T> getColumnType();
+
+    /**
+     * Checks if the cell has a value.
+     *
+     * @return true if the cell has a value, otherwise false
+     */
     boolean isPresent();
+
+    /**
+     * Checks if the cell is empty.
+     *
+     * @return true if the cell is empty, otherwise false
+     */
     boolean isEmpty();
+
+    /**
+     * Performs the given action if the cell has a value.
+     *
+     * @param action the action to perform
+     */
     void ifPresent(Consumer<? super T> action);
+
+    /**
+     * Performs the given action if the cell has a value, otherwise performs the empty action.
+     *
+     * @param action the action to perform if the cell has a value
+     * @param emptyAction the action to perform if the cell is empty
+     */
     void ifPresentOrElse(Consumer<? super T> action, Runnable emptyAction);
+
+    /**
+     * Filters the cell value using the given predicate.
+     *
+     * @param predicate the predicate to apply
+     * @return a cell containing the value if it matches the predicate, otherwise an empty cell
+     */
     KhCell<T> filter(Predicate<? super T> predicate);
+
+    /**
+     * Maps the cell value using the given function.
+     *
+     * @param mapper the function to apply
+     * @param <U> the type of the result
+     * @return a cell containing the result of applying the function
+     */
     <U> KhCell<U> map(Function<? super T, ? extends U> mapper);
+
+    /**
+     * Flat maps the cell value using the given function.
+     *
+     * @param mapper the function to apply
+     * @param <U> the type of the result
+     * @return a cell containing the result of applying the function
+     */
     <U> KhCell<U> flatMap(Function<? super T, ? extends KhCell<? extends U>> mapper);
+
+    /**
+     * Returns the cell if it has a value, otherwise returns the result of the supplier.
+     *
+     * @param supplier the supplier to use if the cell is empty
+     * @return the cell or the result of the supplier
+     */
     KhCell<T> or(Supplier<? extends KhCell<? extends T>> supplier);
+
+    /**
+     * Returns a stream containing the cell value if it is present, otherwise an empty stream.
+     *
+     * @return a stream containing the cell value or an empty stream
+     */
     Stream<T> stream();
+
+    /**
+     * Returns the cell value if it is present, otherwise returns the specified value.
+     *
+     * @param other the value to return if the cell is empty
+     * @return the cell value or the specified value
+     */
     T orElse(T other);
+
+    /**
+     * Returns the cell value if it is present, otherwise returns the result of the supplier.
+     *
+     * @param supplier the supplier to use if the cell is empty
+     * @return the cell value or the result of the supplier
+     */
     T orElseGet(Supplier<? extends T> supplier);
+
+    /**
+     * Returns the cell value if it is present, otherwise throws NoSuchElementException.
+     *
+     * @return the cell value
+     * @throws NoSuchElementException if the cell is empty
+     */
     T orElseThrow();
+
+    /**
+     * Returns the cell value if it is present, otherwise throws an exception provided by the supplier.
+     *
+     * @param exceptionSupplier the supplier to use if the cell is empty
+     * @param <X> the type of the exception
+     * @return the cell value
+     * @throws X if the cell is empty
+     */
     <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X;
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/column/KhColumn.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/column/KhColumn.java
@@ -24,12 +24,45 @@
 
 package keyhub.data.structure.column;
 
+/**
+ * Interface representing a column in a data structure.
+ *
+ * @param <T> the type of the column
+ */
 public interface KhColumn<T> {
+
+    /**
+     * Creates a new column with the specified name and type.
+     *
+     * @param columnName the name of the column
+     * @param columnType the type of the column
+     * @param <T> the type of the column
+     * @return a new column
+     */
     static <T> KhColumn<T> of(String columnName, Class<T> columnType) {
         return KhColumnImplement.of(columnName, columnType);
     }
+
+    /**
+     * Gets the name of the column.
+     *
+     * @return the column name
+     */
     String getColumnName();
+
+    /**
+     * Gets the type of the column.
+     *
+     * @return the column type
+     */
     Class<T> getColumnType();
+
+    /**
+     * Checks if this column is equal to another object.
+     *
+     * @param o the object to compare with
+     * @return true if this column is equal to the other object, otherwise false
+     */
     @Override
     boolean equals(Object o);
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/converter/KhObjectConverter.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/converter/KhObjectConverter.java
@@ -27,11 +27,22 @@ package keyhub.data.structure.converter;
 import java.lang.reflect.Field;
 import java.util.*;
 
+/**
+ * Utility class for converting objects to maps.
+ */
 public class KhObjectConverter {
-    public static Map<String, Object> convertToMap(Object object){
+
+    /**
+     * Converts an object to a map where the keys are the field names and the values are the field values.
+     *
+     * @param object the object to convert
+     * @return a map representation of the object
+     * @throws RuntimeException if the object fields cannot be accessed
+     */
+    public static Map<String, Object> convertToMap(Object object) {
         Map<String, Object> map = new WeakHashMap<>();
         Field[] fields = object.getClass().getDeclaredFields();
-        for(Field field : fields){
+        for (Field field : fields) {
             field.setAccessible(true);
             try {
                 map.put(field.getName(), field.get(object));
@@ -42,9 +53,15 @@ public class KhObjectConverter {
         return map;
     }
 
+    /**
+     * Converts a list of objects to a list of maps.
+     *
+     * @param objectList the list of objects to convert
+     * @return a list of map representations of the objects
+     */
     public static List<Map<String, Object>> convertToMapList(List<?> objectList) {
         List<Map<String, Object>> mapList = new ArrayList<>();
-        for(Object object : objectList){
+        for (Object object : objectList) {
             mapList.add(convertToMap(object));
         }
         return mapList;

--- a/kh-data-structure/src/main/java/keyhub/data/structure/function/KhCellPredicate.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/function/KhCellPredicate.java
@@ -28,9 +28,18 @@ import keyhub.data.structure.cell.KhCell;
 
 import java.util.function.Predicate;
 
-
+/**
+ * Functional interface representing a predicate (boolean-valued function) of a KhCell.
+ */
 @FunctionalInterface
 public interface KhCellPredicate extends Predicate<KhCell<?>> {
+
+    /**
+     * Evaluates this predicate on the given cell.
+     *
+     * @param cell the input cell
+     * @return true if the input cell matches the predicate, otherwise false
+     */
     @Override
     boolean test(KhCell cell);
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/function/KhCellSelector.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/function/KhCellSelector.java
@@ -29,11 +29,27 @@ import keyhub.data.structure.row.KhRow;
 
 import java.util.function.Function;
 
+/**
+ * Functional interface representing a selector that extracts a KhCell from a KhRow.
+ */
 @FunctionalInterface
 public interface KhCellSelector extends Function<KhRow, KhCell<?>> {
+
+    /**
+     * Applies this selector to the given row.
+     *
+     * @param row the input row
+     * @return the selected cell
+     */
     @Override
     KhCell<?> apply(KhRow row);
 
+    /**
+     * Creates a cell selector for the specified column name.
+     *
+     * @param columnName the name of the column
+     * @return a cell selector for the specified column
+     */
     static KhCellSelector column(String columnName) {
         return row -> row.findCell(columnName).orElse(null);
     }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/function/KhColumnSelector.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/function/KhColumnSelector.java
@@ -1,10 +1,10 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 KH
+ * Copyright \(c\) 2024 KH
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
+ * of this software and associated documentation files \(the "Software"\), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
@@ -29,15 +29,32 @@ import keyhub.data.structure.schema.KhSchema;
 
 import java.util.function.Function;
 
+/**
+ * Functional interface representing a selector that extracts a KhColumn from a KhSchema.
+ */
 @FunctionalInterface
 public interface KhColumnSelector extends Function<KhSchema, KhColumn<?>> {
+
+    /**
+     * Applies this selector to the given schema.
+     *
+     * @param schema the input schema
+     * @return the selected column
+     */
     @Override
     KhColumn<?> apply(KhSchema schema);
 
-    static KhColumnSelector column(String columnName){
+    /**
+     * Creates a column selector for the specified column name.
+     *
+     * @param columnName the name of the column
+     * @return a column selector for the specified column
+     * @throws IllegalArgumentException if the column is not found in the schema
+     */
+    static KhColumnSelector column(String columnName) {
         return schema -> {
             int index = schema.getColumnIndex(columnName);
-            if(index == -1){
+            if (index == -1) {
                 throw new IllegalArgumentException("KhColumn not found");
             }
             return schema.getColumnSchema(index);

--- a/kh-data-structure/src/main/java/keyhub/data/structure/function/KhRowPredicate.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/function/KhRowPredicate.java
@@ -28,16 +28,41 @@ import keyhub.data.structure.row.KhRow;
 
 import java.util.function.Predicate;
 
+/**
+ * Functional interface representing a predicate (boolean-valued function) of a KhRow.
+ */
 @FunctionalInterface
 public interface KhRowPredicate extends Predicate<KhRow> {
+
+    /**
+     * Evaluates this predicate on the given row.
+     *
+     * @param row the input row
+     * @return true if the input row matches the predicate, otherwise false
+     */
     @Override
     boolean test(KhRow row);
 
+    /**
+     * Creates a row predicate that evaluates a cell in the specified column using the given cell predicate.
+     *
+     * @param columnName the name of the column
+     * @param predicate the cell predicate
+     * @return a row predicate that evaluates the specified column
+     */
     static KhRowPredicate is(String columnName, KhCellPredicate predicate) {
         return tblRow -> tblRow.findCell(columnName)
                 .map(predicate::test)
                 .orElse(false);
     }
+
+    /**
+     * Creates a row predicate that evaluates a cell at the specified column index using the given cell predicate.
+     *
+     * @param columnIndex the index of the column
+     * @param predicate the cell predicate
+     * @return a row predicate that evaluates the specified column index
+     */
     static KhRowPredicate is(int columnIndex, KhCellPredicate predicate) {
         return tblRow -> predicate.test(tblRow.getCell(columnIndex));
     }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/join/KhJoin.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/join/KhJoin.java
@@ -26,24 +26,120 @@ package keyhub.data.structure.join;
 
 import keyhub.data.structure.function.KhColumnSelector;
 
+/**
+ * Interface representing a join operation between two data structures.
+ *
+ * @param <E> the type of the joinable entity
+ * @param <T> the type of the join operation
+ */
 public interface KhJoin<E extends KhJoinable, T extends KhJoin<E, T>> {
+
+    /**
+     * Executes the join operation and returns the result as a single entity.
+     *
+     * @return the result of the join operation
+     */
     E toOne();
 
+    /**
+     * Specifies the key to join on.
+     *
+     * @param key the key to join on
+     * @return the join operation
+     */
     KhJoin<E, T> on(String key);
+
+    /**
+     * Specifies the keys to join on.
+     *
+     * @param leftKey the key from the left data structure
+     * @param rightKey the key from the right data structure
+     * @return the join operation
+     */
     KhJoin<E, T> on(String leftKey, String rightKey);
 
+    /**
+     * Selects all columns from both data structures.
+     *
+     * @return the join operation
+     */
     KhJoin<E, T> selectAll();
 
+    /**
+     * Selects specific columns from the left data structure.
+     *
+     * @param selectors the column selectors
+     * @return the join operation
+     */
     KhJoin<E, T> selectFromLeft(KhColumnSelector... selectors);
+
+    /**
+     * Selects a specific column from the left data structure.
+     *
+     * @param column the column name
+     * @return the join operation
+     */
     KhJoin<E, T> selectFromLeft(String column);
+
+    /**
+     * Selects specific columns from the left data structure.
+     *
+     * @param columns the column names
+     * @return the join operation
+     */
     KhJoin<E, T> selectFromLeft(String... columns);
+
+    /**
+     * Selects all columns from the left data structure.
+     *
+     * @return the join operation
+     */
     KhJoin<E, T> selectAllFromLeft();
 
+    /**
+     * Selects specific columns from the right data structure.
+     *
+     * @param selectors the column selectors
+     * @return the join operation
+     */
     KhJoin<E, T> selectFromRight(KhColumnSelector... selectors);
+
+    /**
+     * Selects a specific column from the right data structure.
+     *
+     * @param column the column name
+     * @return the join operation
+     */
     KhJoin<E, T> selectFromRight(String column);
+
+    /**
+     * Selects specific columns from the right data structure.
+     *
+     * @param columns the column names
+     * @return the join operation
+     */
     KhJoin<E, T> selectFromRight(String... columns);
+
+    /**
+     * Selects all columns from the right data structure.
+     *
+     * @return the join operation
+     */
     KhJoin<E, T> selectAllFromRight();
 
+    /**
+     * Gets the index of a column from the left data structure.
+     *
+     * @param column the column name
+     * @return the column index
+     */
     int getColumnIndexFromLeft(String column);
+
+    /**
+     * Gets the index of a column from the right data structure.
+     *
+     * @param column the column name
+     * @return the column index
+     */
     int getColumnIndexFromRight(String column);
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/join/KhJoinable.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/join/KhJoinable.java
@@ -24,5 +24,8 @@
 
 package keyhub.data.structure.join;
 
+/**
+ * Interface representing a joinable entity in a data structure.
+ */
 public interface KhJoinable {
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/row/KhRow.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/row/KhRow.java
@@ -32,28 +32,105 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Interface representing a row in a table, which consists of multiple cells.
+ */
 public interface KhRow extends Iterable<KhCell> {
+
+    /**
+     * Creates a row from a schema and a variable number of values.
+     *
+     * @param schema the schema of the row
+     * @param values the values of the row
+     * @return a KhRow instance
+     */
     static KhRow of(KhSchema schema, Object... values) {
         return KhRowImplement.of(schema, Arrays.stream(values).toList());
     }
+
+    /**
+     * Creates a row from a variable number of cells.
+     *
+     * @param cells the cells of the row
+     * @return a KhRow instance
+     */
     static KhRow of(KhCell... cells) {
         return KhRowImplement.of(cells);
     }
+
+    /**
+     * Creates a row from a list of cells.
+     *
+     * @param cells the cells of the row
+     * @return a KhRow instance
+     */
     static KhRow of(List<KhCell> cells) {
         return KhRowImplement.of(cells);
     }
+
+    /**
+     * Creates a row from a schema and a list of values.
+     *
+     * @param schema the schema of the row
+     * @param values the values of the row
+     * @return a KhRow instance
+     */
     static KhRow of(KhSchema schema, List<Object> values) {
         return KhRowImplement.of(schema, values);
     }
 
+    /**
+     * Gets the schema of the row.
+     *
+     * @return the schema
+     */
     KhSchema getSchema();
+
+    /**
+     * Converts the row to a list of values.
+     *
+     * @return a list of values
+     */
     List<Object> toList();
+
+    /**
+     * Finds a cell by its column name.
+     *
+     * @param columnName the name of the column
+     * @param <T> the type of the cell
+     * @return an Optional containing the cell if found, or empty if not found
+     */
     <T> Optional<KhCell<T>> findCell(String columnName);
+
+    /**
+     * Gets a cell by its column index.
+     *
+     * @param columnIndex the index of the column
+     * @param <T> the type of the cell
+     * @return the cell
+     */
     <T> KhCell<T> getCell(int columnIndex);
 
+    /**
+     * Gets all cells in the row.
+     *
+     * @return a list of cells
+     */
     List<KhCell> getCells();
 
-
+    /**
+     * Selects a subset of columns from the row.
+     *
+     * @param columns the names of the columns to select
+     * @return a new KhRow instance containing the selected columns
+     */
     KhRow select(String[] columns);
+
+    /**
+     * Selects a subset of columns from the row.
+     *
+     * @param columns the columns to select
+     * @return a new KhRow instance containing the selected columns
+     */
     KhRow select(KhColumn[] columns);
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/schema/KhSchema.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/schema/KhSchema.java
@@ -30,36 +30,124 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * Interface representing a schema for a table, which consists of multiple columns.
+ */
 public interface KhSchema extends Iterable<KhColumn> {
+
+    /**
+     * Creates an empty schema.
+     *
+     * @return an empty KhSchema instance
+     */
     static KhSchema empty() {
         return KhSchemaImplement.empty();
     }
+
+    /**
+     * Creates a schema from a list of columns.
+     *
+     * @param columns the list of columns to create the schema from
+     * @return a KhSchema instance
+     */
     static KhSchema from(List<KhColumn> columns) {
         return KhSchemaImplement.from(columns);
     }
+
+    /**
+     * Creates a schema from an existing schema.
+     *
+     * @param schema the existing schema to create the new schema from
+     * @return a KhSchema instance
+     */
     static KhSchema from(KhSchema schema) {
         return KhSchemaImplement.from(schema);
     }
+
+    /**
+     * Creates a builder for KhSchemaValue.
+     *
+     * @return a KhSchemaValueBuilder instance
+     */
     static KhSchemaValue.KhSchemaValueBuilder builder() {
         return KhSchemaImplement.builder();
     }
 
+    /**
+     * Gets the number of columns in the schema.
+     *
+     * @return the number of columns
+     */
     int getColumnSize();
+
+    /**
+     * Gets the names of all columns in the schema.
+     *
+     * @return a list of column names
+     */
     List<String> getColumnNames();
+
+    /**
+     * Gets the types of all columns in the schema.
+     *
+     * @return a map of column names to their types
+     */
     Map<String, Class<?>> getColumnTypes();
 
+    /**
+     * Finds a column schema by its name.
+     *
+     * @param columnName the name of the column to find
+     * @return an Optional containing the column schema if found, or empty if not found
+     */
     Optional<KhColumn<?>> findColumnSchema(String columnName);
 
+    /**
+     * Gets the schema of a column by its index.
+     *
+     * @param index the index of the column
+     * @param <T> the type of the column
+     * @return the column schema
+     */
     <T> KhColumn<T> getColumnSchema(int index);
 
+    /**
+     * Checks if this schema is equal to another object.
+     *
+     * @param o the object to compare with
+     * @return true if the schemas are equal, false otherwise
+     */
     @Override
     boolean equals(Object o);
 
+    /**
+     * Gets the schemas of all columns.
+     *
+     * @return a list of column schemas
+     */
     List<KhColumn> getColumnSchemas();
 
+    /**
+     * Gets the index of a column by its name.
+     *
+     * @param columnName the name of the column
+     * @return the index of the column
+     */
     int getColumnIndex(String columnName);
 
+    /**
+     * Checks if the schema contains a column with the specified name.
+     *
+     * @param column the name of the column to check
+     * @return true if the column is present, false otherwise
+     */
     boolean contains(String column);
 
+    /**
+     * Selects a subset of columns from the schema.
+     *
+     * @param columns the names of the columns to select
+     * @return a new KhSchema instance containing the selected columns
+     */
     KhSchema select(String... columns);
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/schema/KhSchemaBasedStructure.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/schema/KhSchemaBasedStructure.java
@@ -26,11 +26,54 @@ package keyhub.data.structure.schema;
 
 import keyhub.data.structure.column.KhColumn;
 
+/**
+ * Interface representing a structure based on a schema, providing methods to access column schemas and metadata.
+ */
 public interface KhSchemaBasedStructure {
+
+    /**
+     * Gets the schema of a column by its index.
+     *
+     * @param index the index of the column
+     * @return the column schema
+     */
     KhColumn<?> getColumnSchema(int index);
+
+    /**
+     * Gets the schema of the structure.
+     *
+     * @return the schema
+     */
     KhSchema getSchema();
+
+    /**
+     * Gets the number of columns in the structure.
+     *
+     * @return the number of columns
+     */
     int getColumnSize();
+
+    /**
+     * Gets the name of a column by its index.
+     *
+     * @param index the index of the column
+     * @return the name of the column
+     */
     String getColumnName(int index);
+
+    /**
+     * Gets the type of a column by its index.
+     *
+     * @param index the index of the column
+     * @return the type of the column
+     */
     Class<?> getColumnType(int index);
+
+    /**
+     * Gets the index of a column by its name.
+     *
+     * @param column the name of the column
+     * @return the index of the column
+     */
     int getColumnIndex(String column);
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/stream/KhStream.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/stream/KhStream.java
@@ -37,22 +37,98 @@ import java.util.List;
 import java.util.stream.BaseStream;
 import java.util.stream.Stream;
 
+/**
+ * Interface representing a stream of KhRow objects, providing methods for selection, filtering, joining, and conversion.
+ */
 public interface KhStream extends BaseStream<KhRow, KhStream>, KhSchemaBasedStructure, KhJoinable {
-    static KhStream from(KhTable tbl){
+
+    /**
+     * Creates a KhStream from a KhTable.
+     *
+     * @param tbl the KhTable to create the stream from
+     * @return a KhStream instance
+     */
+    static KhStream from(KhTable tbl) {
         return KhStreamImplement.from(tbl);
     }
+
+    /**
+     * Creates a KhStream from a schema and a stream of KhRow.
+     *
+     * @param schema the schema to be used by the stream
+     * @param rowStream the stream of KhRow to be used
+     * @return a KhStream instance
+     */
     static KhStream of(KhSchema schema, Stream<KhRow> rowStream) {
         return KhStreamImplement.of(schema, rowStream);
     }
 
+    /**
+     * Selects columns by their names.
+     *
+     * @param columns the names of the columns to select
+     * @return the current KhStream instance
+     */
     KhStream select(String... columns);
+
+    /**
+     * Selects columns by their KhColumn instances.
+     *
+     * @param columns the KhColumn instances to select
+     * @return the current KhStream instance
+     */
     KhStream select(KhColumn<?>... columns);
+
+    /**
+     * Selects columns using KhCellSelector instances.
+     *
+     * @param selector the KhCellSelector instances to use for selection
+     * @return the current KhStream instance
+     */
     KhStream select(KhCellSelector... selector);
+
+    /**
+     * Filters rows based on a KhRowPredicate.
+     *
+     * @param filter the KhRowPredicate to use for filtering rows
+     * @return the current KhStream instance
+     */
     KhStream where(KhRowPredicate filter);
+
+    /**
+     * Performs a left join with another KhTable.
+     *
+     * @param tbl the KhTable to join with
+     * @return a KhStreamJoin instance representing the left join result
+     */
     KhStreamJoin leftJoin(KhTable tbl);
+
+    /**
+     * Performs an inner join with another KhTable.
+     *
+     * @param tbl the KhTable to join with
+     * @return a KhStreamJoin instance representing the inner join result
+     */
     KhStreamJoin innerJoin(KhTable tbl);
 
+    /**
+     * Returns the underlying stream of KhRow.
+     *
+     * @return the stream of KhRow
+     */
     Stream<KhRow> getRowStream();
+
+    /**
+     * Converts the stream to a list of KhRow.
+     *
+     * @return a list of KhRow
+     */
     List<KhRow> toList();
+
+    /**
+     * Converts the stream to a KhTable.
+     *
+     * @return a KhTable instance
+     */
     KhTable toTable();
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/stream/join/KhStreamJoin.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/stream/join/KhStreamJoin.java
@@ -28,18 +28,87 @@ import keyhub.data.structure.function.KhColumnSelector;
 import keyhub.data.structure.join.KhJoin;
 import keyhub.data.structure.stream.KhStream;
 
+/**
+ * Interface representing a join operation between two KhStream instances.
+ */
 public interface KhStreamJoin extends KhJoin<KhStream, KhStreamJoin> {
 
+    /**
+     * Specifies the key column for the join operation, assuming the same key column name in both streams.
+     *
+     * @param key the name of the key column in both streams
+     * @return the current KhStreamJoin instance
+     */
     KhStreamJoin on(String key);
+
+    /**
+     * Specifies the key columns for the join operation, with different column names in the left and right streams.
+     *
+     * @param leftKey the name of the key column in the left stream
+     * @param rightKey the name of the key column in the right stream
+     * @return the current KhStreamJoin instance
+     */
     KhStreamJoin on(String leftKey, String rightKey);
 
+    /**
+     * Selects specific columns from the left stream for the join result using column selectors.
+     *
+     * @param selectors the column selectors for the left stream
+     * @return the current KhStreamJoin instance
+     */
     KhStreamJoin selectFromLeft(KhColumnSelector... selectors);
+
+    /**
+     * Selects a specific column from the left stream for the join result.
+     *
+     * @param column the name of the column in the left stream
+     * @return the current KhStreamJoin instance
+     */
     KhStreamJoin selectFromLeft(String column);
+
+    /**
+     * Selects specific columns from the left stream for the join result.
+     *
+     * @param columns the names of the columns in the left stream
+     * @return the current KhStreamJoin instance
+     */
     KhStreamJoin selectFromLeft(String... columns);
+
+    /**
+     * Selects all columns from the left stream for the join result.
+     *
+     * @return the current KhStreamJoin instance
+     */
     KhStreamJoin selectAllFromLeft();
 
+    /**
+     * Selects specific columns from the right stream for the join result using column selectors.
+     *
+     * @param selectors the column selectors for the right stream
+     * @return the current KhStreamJoin instance
+     */
     KhStreamJoin selectFromRight(KhColumnSelector... selectors);
+
+    /**
+     * Selects a specific column from the right stream for the join result.
+     *
+     * @param column the name of the column in the right stream
+     * @return the current KhStreamJoin instance
+     */
     KhStreamJoin selectFromRight(String column);
+
+    /**
+     * Selects specific columns from the right stream for the join result.
+     *
+     * @param columns the names of the columns in the right stream
+     * @return the current KhStreamJoin instance
+     */
     KhStreamJoin selectFromRight(String... columns);
+
+    /**
+     * Selects all columns from the right stream for the join result.
+     *
+     * @return the current KhStreamJoin instance
+     */
     KhStreamJoin selectAllFromRight();
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/stream/join/inner/KhStreamInnerJoin.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/stream/join/inner/KhStreamInnerJoin.java
@@ -28,10 +28,29 @@ import keyhub.data.structure.stream.KhStream;
 import keyhub.data.structure.stream.join.KhStreamJoin;
 import keyhub.data.structure.table.KhTable;
 
+/**
+ * Interface representing an inner join operation between a KhStream and a KhTable.
+ */
 public interface KhStreamInnerJoin extends KhStreamJoin {
+
+    /**
+     * Creates an inner join between a KhStream and a KhTable.
+     *
+     * @param left the left stream in the join operation
+     * @param right the right table in the join operation
+     * @return a KhStreamJoin instance representing the inner join result
+     */
     static KhStreamJoin of(KhStream left, KhTable right) {
         return new KhLeftStreamInnerJoinImplement(left, right);
     }
+
+    /**
+     * Creates an inner join between a KhTable and a KhStream.
+     *
+     * @param left the left table in the join operation
+     * @param right the right stream in the join operation
+     * @return a KhStreamJoin instance representing the inner join result
+     */
     static KhStreamJoin of(KhTable left, KhStream right){
         return new KhRightStreamInnerJoinImplement(left, right);
     }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/stream/join/left/KhStreamLeftJoin.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/stream/join/left/KhStreamLeftJoin.java
@@ -28,11 +28,30 @@ import keyhub.data.structure.stream.KhStream;
 import keyhub.data.structure.stream.join.KhStreamJoin;
 import keyhub.data.structure.table.KhTable;
 
+/**
+ * Interface representing a left join operation between a KhStream and a KhTable.
+ */
 public interface KhStreamLeftJoin extends KhStreamJoin {
+
+    /**
+     * Creates a left join between a KhStream and a KhTable.
+     *
+     * @param left the left stream in the join operation
+     * @param right the right table in the join operation
+     * @return a KhStreamJoin instance representing the left join result
+     */
     static KhStreamJoin of(KhStream left, KhTable right) {
         return new KhLeftStreamLeftJoinImplement(left, right);
     }
-    static KhStreamJoin of(KhTable left, KhStream right){
+
+    /**
+     * Creates a left join between a KhTable and a KhStream.
+     *
+     * @param left the left table in the join operation
+     * @param right the right stream in the join operation
+     * @return a KhStreamJoin instance representing the left join result
+     */
+    static KhStreamJoin of(KhTable left, KhStream right) {
         return new KhRightStreamLeftJoinImplement(left, right);
     }
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/table/KhTable.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/table/KhTable.java
@@ -37,43 +37,198 @@ import keyhub.data.structure.table.query.KhTableQuery;
 import java.util.*;
 import java.util.stream.Stream;
 
+/**
+ * Represents a table structure backed by a schema, capable of performing various
+ * operations such as querying, streaming, and joining with other table or stream-based
+ * structures.
+ *
+ * This interface extends {@code Iterable<KhRow>}, {@code KhSchemaBasedStructure}, and
+ * {@code KhJoinable}, offering methods to manipulate and retrieve data stored within
+ * the table.
+ */
 public interface KhTable extends Iterable<KhRow>, KhSchemaBasedStructure, KhJoinable {
 
+    /**
+     * Returns an empty instance of {@code KhTable}.
+     *
+     * @return an empty {@code KhTable} instance
+     */
     static KhTable empty() {
         return KhTableImplement.empty();
     }
+
+    /**
+     * Returns an empty instance of {@code KhTable} with the specified schema.
+     *
+     * @param schema the schema to be used by the returned empty table
+     * @return an empty {@code KhTable} instance based on the provided schema
+     */
     static KhTable empty(KhSchema schema) {
         return KhTableImplement.empty(schema);
     }
+
+    /**
+     * Creates a {@code KhTable} instance from a given list. The list can contain
+     * elements of different types, including {@code KhRow} and {@code Map<String, Object>}.
+     * Based on the type of the first element, the method will either create a table
+     * with rows directly from the list or convert the list of maps into a table.
+     *
+     * @param list the list of objects from which the {@code KhTable} will be created.
+     *             The list can be null or empty, which will result in an empty table.
+     * @return a {@code KhTable} instance created from the provided list.
+     */
     static KhTable from(List<?> list) {
         return KhTableImplement.from(list);
     }
+
+    /**
+     * Creates a {@code KhTable} instance from the given {@code KhStream}.
+     * The method extracts all rows from the stream and constructs a table
+     * using those rows.
+     *
+     * @param stream the {@code KhStream} from which the {@code KhTable} will be created.
+     *               Must not be null.
+     * @return a {@code KhTable} instance containing rows extracted from the provided {@code KhStream}.
+     */
     static KhTable from(KhStream stream){
         return KhTableImplement.from(stream);
     }
+
+    /**
+     * Creates a new instance of {@code KhTable} using the specified schema and raw row data.
+     *
+     * @param schema the {@code KhSchema} defining the structure and columns of the table.
+     * @param rawRows a list of raw data rows, where each row is represented as a list of objects.
+     *                The data in each row should align with the columns defined in the schema.
+     * @return a {@code KhTable} instance populated with the supplied raw row data and structured
+     *         according to the specified schema.
+     */
     static KhTable of(KhSchema schema, List<List<Object>> rawRows){
         return KhTableImplement.of(schema, rawRows);
     }
 
+    /**
+     * Creates a builder for constructing a {@code KhTable} with the specified schema.
+     *
+     * @param schema the schema to be used by the builder
+     * @return a {@code KhTableBuilder} instance for constructing a table
+     */
     static KhTableBuilder builder(KhSchema schema){
         return KhTableBuilder.forRowSet(schema);
     }
 
+    /**
+     * Returns the number of rows in the table.
+     *
+     * @return the row count
+     */
     int count();
+
+    /**
+     * Retrieves the row at the specified index.
+     *
+     * @param index the index of the row to retrieve
+     * @return the {@code KhRow} at the specified index
+     */
     KhRow getRow(int index);
+
+    /**
+     * Returns a list of all rows in the table.
+     *
+     * @return a list of {@code KhRow} instances
+     */
     List<KhRow> getRows();
+
+    /**
+     * Retrieves the raw data of the row at the specified index.
+     *
+     * @param index the index of the row to retrieve
+     * @return a list of objects representing the raw data of the row
+     */
     List<Object> getRawRow(int index);
+
+    /**
+     * Retrieves the cell at the specified column and row indices.
+     *
+     * @param columnIndex the index of the column
+     * @param rowIndex the index of the row
+     * @return the {@code KhCell} at the specified column and row indices
+     */
     KhCell<?> getCell(int columnIndex, int rowIndex);
+
+    /**
+     * Finds the cell at the specified column name and row index.
+     *
+     * @param columnName the name of the column
+     * @param rowIndex the index of the row
+     * @return an {@code Optional} containing the {@code KhCell} if found, or empty if not found
+     */
     Optional<KhCell<?>> findCell(String columnName, int rowIndex);
 
+    /**
+     * Returns a stream of rows in the table.
+     *
+     * @return a {@code Stream} of {@code KhRow} instances
+     */
     Stream<KhRow> stream();
+
+    /**
+     * Returns a query object for querying the table.
+     *
+     * @return a {@code KhTableQuery} instance
+     */
     KhTableQuery query();
+
+    /**
+     * Performs a left join with the specified table.
+     *
+     * @param right the table to join with
+     * @return a {@code KhTableJoin} representing the result of the left join
+     */
     KhTableJoin leftJoin(KhTable right);
+
+    /**
+     * Performs an inner join with the specified table.
+     *
+     * @param right the table to join with
+     * @return a {@code KhTableJoin} representing the result of the inner join
+     */
     KhTableJoin innerJoin(KhTable right);
+
+    /**
+     * Performs a left join with the specified stream.
+     *
+     * @param right the stream to join with
+     * @return a {@code KhStreamJoin} representing the result of the left join
+     */
     KhStreamJoin leftJoin(KhStream right);
+
+    /**
+     * Performs an inner join with the specified stream.
+     *
+     * @param right the stream to join with
+     * @return a {@code KhStreamJoin} representing the result of the inner join
+     */
     KhStreamJoin innerJoin(KhStream right);
 
+    /**
+     * Converts the table to a list of maps, where each map represents a row.
+     *
+     * @return a list of maps representing the rows of the table
+     */
     List<Map<String, Object>> toRowMapList();
+
+    /**
+     * Converts the table to a map of column lists, where each list contains the values of a column.
+     *
+     * @return a map of column lists
+     */
     Map<String, List<Object>> toColumnListMap();
+
+    /**
+     * Converts the table to a stream.
+     *
+     * @return a {@code KhStream} representing the table
+     */
     KhStream toStream();
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/table/KhTableBuilder.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/table/KhTableBuilder.java
@@ -29,13 +29,57 @@ import keyhub.data.structure.schema.KhSchema;
 
 import java.util.List;
 
+/**
+ * Interface for building a KhTable with various methods to add rows and raw data.
+ */
 public interface KhTableBuilder {
+
+    /**
+     * Creates a KhTableBuilder for a given schema.
+     *
+     * @param schema the schema to be used by the builder
+     * @return a KhTableBuilder instance
+     */
     static KhTableBuilder forRowSet(KhSchema schema) {
         return KhTableBuilderImplement.forRowSet(schema);
     }
+
+    /**
+     * Adds a raw row to the table being built.
+     *
+     * @param row a list of objects representing the raw row data
+     * @return the current KhTableBuilder instance
+     */
     KhTableBuilder addRawRow(List<Object> row);
+
+    /**
+     * Adds multiple raw rows to the table being built.
+     *
+     * @param rows a list of lists, where each inner list represents a raw row
+     * @return the current KhTableBuilder instance
+     */
     KhTableBuilder addRawRows(List<List<Object>> rows);
+
+    /**
+     * Adds a KhRow to the table being built.
+     *
+     * @param row the KhRow to be added
+     * @return the current KhTableBuilder instance
+     */
     KhTableBuilder addRow(KhRow row);
+
+    /**
+     * Adds multiple KhRows to the table being built.
+     *
+     * @param rows a list of KhRow instances to be added
+     * @return the current KhTableBuilder instance
+     */
     KhTableBuilder addRows(List<KhRow> rows);
+
+    /**
+     * Builds and returns the KhTable instance.
+     *
+     * @return the constructed KhTable instance
+     */
     KhTable build();
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/table/join/KhTableJoin.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/table/join/KhTableJoin.java
@@ -28,23 +28,110 @@ import keyhub.data.structure.join.KhJoin;
 import keyhub.data.structure.table.KhTable;
 import keyhub.data.structure.function.KhColumnSelector;
 
+/**
+ * Interface representing a join operation between two KhTable instances.
+ */
 public interface KhTableJoin extends KhJoin<KhTable, KhTableJoin> {
 
+    /**
+     * Specifies the key column for the join operation, assuming the same key column name in both tables.
+     *
+     * @param sameKey the name of the key column in both tables
+     * @return the current KhTableJoin instance
+     */
     KhTableJoin on(String sameKey);
+
+    /**
+     * Specifies the key columns for the join operation, with different column names in the left and right tables.
+     *
+     * @param leftKey the name of the key column in the left table
+     * @param rightKey the name of the key column in the right table
+     * @return the current KhTableJoin instance
+     */
     KhTableJoin on(String leftKey, String rightKey);
 
+    /**
+     * Selects all columns from both tables for the join result.
+     *
+     * @return the current KhTableJoin instance
+     */
     KhTableJoin selectAll();
 
+    /**
+     * Selects specific columns from the left table for the join result using column selectors.
+     *
+     * @param selectors the column selectors for the left table
+     * @return the current KhTableJoin instance
+     */
     KhTableJoin selectFromLeft(KhColumnSelector... selectors);
+
+    /**
+     * Selects a specific column from the left table for the join result.
+     *
+     * @param column the name of the column in the left table
+     * @return the current KhTableJoin instance
+     */
     KhTableJoin selectFromLeft(String column);
+
+    /**
+     * Selects specific columns from the left table for the join result.
+     *
+     * @param columns the names of the columns in the left table
+     * @return the current KhTableJoin instance
+     */
     KhTableJoin selectFromLeft(String... columns);
+
+    /**
+     * Selects all columns from the left table for the join result.
+     *
+     * @return the current KhTableJoin instance
+     */
     KhTableJoin selectAllFromLeft();
 
+    /**
+     * Selects specific columns from the right table for the join result using column selectors.
+     *
+     * @param selectors the column selectors for the right table
+     * @return the current KhTableJoin instance
+     */
     KhTableJoin selectFromRight(KhColumnSelector... selectors);
+
+    /**
+     * Selects a specific column from the right table for the join result.
+     *
+     * @param column the name of the column in the right table
+     * @return the current KhTableJoin instance
+     */
     KhTableJoin selectFromRight(String column);
+
+    /**
+     * Selects specific columns from the right table for the join result.
+     *
+     * @param columns the names of the columns in the right table
+     * @return the current KhTableJoin instance
+     */
     KhTableJoin selectFromRight(String... columns);
+
+    /**
+     * Selects all columns from the right table for the join result.
+     *
+     * @return the current KhTableJoin instance
+     */
     KhTableJoin selectAllFromRight();
 
+    /**
+     * Retrieves the index of a specific column from the left table.
+     *
+     * @param column the name of the column in the left table
+     * @return the index of the column in the left table
+     */
     int getColumnIndexFromLeft(String column);
+
+    /**
+     * Retrieves the index of a specific column from the right table.
+     *
+     * @param column the name of the column in the right table
+     * @return the index of the column in the right table
+     */
     int getColumnIndexFromRight(String column);
 }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/table/join/inner/KhTableInnerJoin.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/table/join/inner/KhTableInnerJoin.java
@@ -1,10 +1,10 @@
 /*
  * MIT License
  *
- * Copyright (c) 2024 KH
+ * Copyright \(c\) 2024 KH
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
+ * of this software and associated documentation files \(the "Software"\), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
@@ -27,7 +27,18 @@ package keyhub.data.structure.table.join.inner;
 import keyhub.data.structure.table.KhTable;
 import keyhub.data.structure.table.join.KhTableJoin;
 
+/**
+ * Interface representing an inner join operation between two KhTable instances.
+ */
 public interface KhTableInnerJoin extends KhTableJoin {
+
+    /**
+     * Creates an inner join between two KhTable instances.
+     *
+     * @param left the left table in the join operation
+     * @param right the right table in the join operation
+     * @return a KhTableJoin instance representing the inner join result
+     */
     static KhTableJoin of(KhTable left, KhTable right) {
         return new KhTableInnerJoinImplement(left, right);
     }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/table/join/left/KhTableLeftJoin.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/table/join/left/KhTableLeftJoin.java
@@ -27,7 +27,18 @@ package keyhub.data.structure.table.join.left;
 import keyhub.data.structure.table.KhTable;
 import keyhub.data.structure.table.join.KhTableJoin;
 
+/**
+ * Interface representing a left join operation between two KhTable instances.
+ */
 public interface KhTableLeftJoin extends KhTableJoin {
+
+    /**
+     * Creates a left join between two KhTable instances.
+     *
+     * @param left the left table in the join operation
+     * @param right the right table in the join operation
+     * @return a KhTableJoin instance representing the left join result
+     */
     static KhTableJoin of(KhTable left, KhTable right) {
         return new KhTableLeftJoinImplement(left, right);
     }

--- a/kh-data-structure/src/main/java/keyhub/data/structure/table/query/KhTableQuery.java
+++ b/kh-data-structure/src/main/java/keyhub/data/structure/table/query/KhTableQuery.java
@@ -33,14 +33,64 @@ import keyhub.data.structure.schema.KhSchema;
 
 import java.util.stream.Stream;
 
+/**
+ * Interface for querying a KhTable, providing methods to select columns, filter rows, and convert the query result to a table.
+ */
 public interface KhTableQuery {
+
+    /**
+     * Creates a KhTableQuery from a stream of KhRow.
+     *
+     * @param rowStream the stream of KhRow to query
+     * @return a KhTableQuery instance
+     */
     static KhTableQuery from(Stream<KhRow> rowStream) {
         return KhTableQueryImplement.from(rowStream);
     }
+
+    /**
+     * Returns the schema of the table being queried.
+     *
+     * @return the KhSchema of the table
+     */
     KhSchema getSchema();
+
+    /**
+     * Converts the query result to a KhTable.
+     *
+     * @return a KhTable instance containing the query result
+     */
     KhTable toTbl();
+
+    /**
+     * Selects columns by their names.
+     *
+     * @param columns the names of the columns to select
+     * @return the current KhTableQuery instance
+     */
     KhTableQuery select(String... columns);
+
+    /**
+     * Selects columns by their KhColumn instances.
+     *
+     * @param columns the KhColumn instances to select
+     * @return the current KhTableQuery instance
+     */
     KhTableQuery select(KhColumn<?>... columns);
+
+    /**
+     * Selects columns using KhCellSelector instances.
+     *
+     * @param selector the KhCellSelector instances to use for selection
+     * @return the current KhTableQuery instance
+     */
     KhTableQuery select(KhCellSelector... selector);
+
+    /**
+     * Filters rows based on a KhRowPredicate.
+     *
+     * @param filter the KhRowPredicate to use for filtering rows
+     * @return the current KhTableQuery instance
+     */
     KhTableQuery where(KhRowPredicate filter);
 }


### PR DESCRIPTION
JavaDoc comments have been added to various interfaces and classes across the `kh-data-structure` package. This documentation offers detailed explanations of interface methods, parameters, and expected return values, which enhances code readability and helps clarify the intended use of each component. Additionally, the project version in the build.gradle file was modified for consistency.