### PR TITLE
Revert version changes in build configurations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 <dependency>
     <groupId>io.github.keyhub-projects</groupId>
     <artifactId>kh-data-structure</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </dependency>
 ```
 
 ## Gradle
 ```gradle
-implementation 'io.github.keyhub-projects:kh-data-structure:1.0.0'
+implementation 'io.github.keyhub-projects:kh-data-structure:1.0.1'
 ```
 
 # Structure
@@ -58,5 +58,4 @@ public List<OrderDetailView> findOrderedDetailViewList(String userId){
 }
 ```
 
-- [KeyHub-Data-Tbl(한글 설명)_1.2.0](./docs/KeyHub-Data-Tbl(한글설명)_1.2.0.pdf)
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'keyhub'
-version = '2.0.1'
+version = '1.0.1'
 
 repositories {
     mavenCentral()

--- a/kh-data-structure/build.gradle
+++ b/kh-data-structure/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = 'keyhub'
-version = '1.0.0'
+version = '1.0.1'
 
 repositories {
     mavenCentral()
@@ -35,7 +35,7 @@ mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
 
-    coordinates("io.github.keyhub-projects", "kh-data-structure", "1.0.0")
+    coordinates("io.github.keyhub-projects", "kh-data-structure", "1.0.1")
 
     pom {
         name = "kh-data"


### PR DESCRIPTION
This commit reverts the version changes in both the main and 'kh-data-structure' build.gradle files. The primary build file's version is reset from '2.0.1' to '1.0.1', aligning with the 'kh-data-structure' version update from '1.0.0' to '1.0.1'. Additionally, the README file is updated to reflect the correct version number for consistency across documentation and build scripts.